### PR TITLE
Update all neon cyan accents to blue-cyan neon (#00bfff) across the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.5] - 2025-05-18
+### Changed
+- Updated all neon cyan (#00fff7) accents, theme colors, and highlights to blue-cyan neon (#00bfff) for a more modern, cohesive look. See [#10](https://github.com/Justinn/commandnet/issues/10).
+
 ## [0.0.4] - 2025-05-18
 ### Changed
 - Redesigned homepage

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -10,7 +10,7 @@ export default function Header() {
         bgcolor: 'transparent',
         background: 'linear-gradient(90deg, #101624 60%, #0a0f1a 100%)',
         boxShadow: 'none',
-        borderBottom: '0.02rem solid #00fff7',
+        borderBottom: '0.02rem solid #00bfff',
         px: 0,
       }}
     >
@@ -18,12 +18,12 @@ export default function Header() {
         <Typography
           variant="h2"
           sx={{
-            color: '#00fff7',
+            color: '#00bfff',
             fontFamily: 'var(--font-share-tech-mono)',
             fontWeight: 900,
             fontSize: '2.5rem',
             letterSpacing: '0.12em',
-            textShadow: '0 0 2rem #00fff7, 0 0 1rem #00fff7',
+            textShadow: '0 0 2rem #00bfff, 0 0 1rem #00bfff',
             textAlign: 'left',
             flexGrow: 0,
             lineHeight: 1.1,
@@ -32,7 +32,7 @@ export default function Header() {
           CommandNet
         </Typography>
       </Toolbar>
-      <Box sx={{ height: '0.25rem', width: '100%', background: 'linear-gradient(90deg, #00fff7 0%, #0a0f1a 100%)', boxShadow: '0 0 1.5rem #00fff7' }} />
+      <Box sx={{ height: '0.25rem', width: '100%', background: 'linear-gradient(90deg, #00bfff 0%, #0a0f1a 100%)', boxShadow: '0 0 1.5rem #00bfff' }} />
     </AppBar>
   );
 } 

--- a/app/components/MainContent.tsx
+++ b/app/components/MainContent.tsx
@@ -5,7 +5,7 @@ import { Box, Typography } from '@mui/material';
 export default function MainContent() {
   return (
     <Box sx={{ p: { xs: '1.5rem', md: '3rem' }, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: 'calc(100vh - 4rem)' }}>
-      <Typography variant="h3" sx={{ mb: 2, color: '#00fff7', textShadow: '0 0 0.75rem #00fff7' }}>
+      <Typography variant="h3" sx={{ mb: 2, color: '#00bfff', textShadow: '0 0 0.75rem #00bfff' }}>
         Welcome to CommandNet
       </Typography>
       <Typography variant="h6" sx={{ maxWidth: '37.5rem', textAlign: 'center', color: 'text.primary', mb: 4 }}>

--- a/app/components/MuiThemeProvider.tsx
+++ b/app/components/MuiThemeProvider.tsx
@@ -8,7 +8,7 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     primary: {
-      main: '#00fff7', // neon cyan
+      main: '#00bfff', // blue-cyan neon
     },
     background: {
       default: '#0a0f1a',
@@ -16,7 +16,7 @@ const theme = createTheme({
     },
     text: {
       primary: '#e0f7fa',
-      secondary: '#00fff7',
+      secondary: '#00bfff',
     },
   },
   typography: {

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -8,13 +8,15 @@ import AssignmentIcon from '@mui/icons-material/Assignment';
 import PublicIcon from '@mui/icons-material/Public';
 import StorefrontIcon from '@mui/icons-material/Storefront';
 
+const NEON_COLOR = '#00bfff'; // blue-cyan neon (Deep Sky Blue)
+
 const navItems = [
-  { label: 'Home', icon: <HomeIcon sx={{ color: '#00fff7', filter: 'drop-shadow(0 0 0.5rem #00fff7)' }} />, active: true, disabled: false },
-  { label: 'Agent', icon: <PersonIcon sx={{ color: '#00fff7', filter: 'drop-shadow(0 0 0.5rem #00fff7)' }} />, active: false, disabled: true },
-  { label: 'Ships', icon: <RocketLaunchIcon sx={{ color: '#00fff7', filter: 'drop-shadow(0 0 0.5rem #00fff7)' }} />, active: false, disabled: true },
-  { label: 'Contracts', icon: <AssignmentIcon sx={{ color: '#00fff7', filter: 'drop-shadow(0 0 0.5rem #00fff7)' }} />, active: false, disabled: true },
-  { label: 'Systems', icon: <PublicIcon sx={{ color: '#00fff7', filter: 'drop-shadow(0 0 0.5rem #00fff7)' }} />, active: false, disabled: true },
-  { label: 'Markets', icon: <StorefrontIcon sx={{ color: '#00fff7', filter: 'drop-shadow(0 0 0.5rem #00fff7)' }} />, active: false, disabled: true },
+  { label: 'Home', icon: <HomeIcon sx={{ color: NEON_COLOR, filter: `drop-shadow(0 0 0.5rem ${NEON_COLOR})` }} />, active: true, disabled: false },
+  { label: 'Agent', icon: <PersonIcon sx={{ color: NEON_COLOR, filter: `drop-shadow(0 0 0.5rem ${NEON_COLOR})` }} />, active: false, disabled: true },
+  { label: 'Ships', icon: <RocketLaunchIcon sx={{ color: NEON_COLOR, filter: `drop-shadow(0 0 0.5rem ${NEON_COLOR})` }} />, active: false, disabled: true },
+  { label: 'Contracts', icon: <AssignmentIcon sx={{ color: NEON_COLOR, filter: `drop-shadow(0 0 0.5rem ${NEON_COLOR})` }} />, active: false, disabled: true },
+  { label: 'Systems', icon: <PublicIcon sx={{ color: NEON_COLOR, filter: `drop-shadow(0 0 0.5rem ${NEON_COLOR})` }} />, active: false, disabled: true },
+  { label: 'Markets', icon: <StorefrontIcon sx={{ color: NEON_COLOR, filter: `drop-shadow(0 0 0.5rem ${NEON_COLOR})` }} />, active: false, disabled: true },
 ];
 
 export default function Sidebar() {
@@ -31,8 +33,8 @@ export default function Sidebar() {
           width: '14rem',
           boxSizing: 'border-box',
           bgcolor: '#101624',
-          borderRight: '0.125rem solid #00fff7',
-          boxShadow: '0 0 1.5rem #00fff7',
+          borderRight: '0.125rem solid #00bfff',
+          boxShadow: '0 0 1.5rem #00bfff',
           background: 'linear-gradient(135deg, #101624 60%, #2d1a4a 100%)',
         },
       }}
@@ -42,12 +44,12 @@ export default function Sidebar() {
         <Typography
           variant="h6"
           sx={{
-            color: '#00fff7',
+            color: '#00bfff',
             fontFamily: 'var(--font-share-tech-mono)',
             fontWeight: 700,
             fontSize: '1.1rem',
             letterSpacing: '0.18em',
-            textShadow: '0 0 1rem #00fff7',
+            textShadow: '0 0 1rem #00bfff',
             mb: 2,
             ml: 2,
             textTransform: 'uppercase',
@@ -63,33 +65,40 @@ export default function Sidebar() {
                 selected={item.active}
                 disabled={item.disabled}
                 sx={{
-                  borderRadius: '0.5rem',
-                  mx: 1,
-                  mb: 1,
-                  background: item.active ? 'rgba(0,255,247,0.08)' : 'none',
-                  boxShadow: item.active ? '0 0 1rem #00fff7' : 'none',
+                  borderRadius: '0.25rem',
+                  mx: 0.5,
+                  mb: 0.5,
+                  py: 0.5,
+                  minHeight: '2.2rem',
+                  background: item.active
+                    ? 'linear-gradient(90deg, rgba(16,22,36,0.95) 60%, rgba(45,26,74,0.95) 100%)'
+                    : 'rgba(16,22,36,0.7)',
+                  boxShadow: item.active ? `0 0 0.5rem ${NEON_COLOR}` : 'none',
+                  border: item.active ? `1px solid ${NEON_COLOR}` : '1px solid rgba(0,191,255,0.08)',
                   opacity: item.disabled ? 0.5 : 1,
                   cursor: item.disabled ? 'not-allowed' : 'pointer',
+                  color: NEON_COLOR,
                   '&:hover': item.disabled
                     ? {}
                     : {
-                        background: 'rgba(0,255,247,0.15)',
-                        boxShadow: '0 0 1rem #00fff7',
+                        background: 'linear-gradient(90deg, rgba(16,22,36,1) 60%, rgba(45,26,74,1) 100%)',
+                        boxShadow: `0 0 0.7rem ${NEON_COLOR}`,
+                        border: `1px solid ${NEON_COLOR}`,
                       },
                   transition: 'all 0.2s',
                 }}
               >
-                <ListItemIcon sx={{ minWidth: '2.2rem' }}>{item.icon}</ListItemIcon>
+                <ListItemIcon sx={{ minWidth: '1.7rem', fontSize: '1.2rem' }}>{item.icon}</ListItemIcon>
                 <ListItemText
                   primary={item.label}
                   slotProps={{
                     primary: {
                       sx: {
-                        color: '#00fff7',
+                        color: NEON_COLOR,
                         fontFamily: 'var(--font-share-tech-mono)',
                         fontWeight: 600,
-                        fontSize: '1.05rem',
-                        letterSpacing: '0.15em',
+                        fontSize: '0.95rem',
+                        letterSpacing: '0.12em',
                       },
                     },
                   }}


### PR DESCRIPTION
This PR updates all UI elements, theme, and components to use a consistent blue-cyan neon (#00bfff, Deep Sky Blue) accent color instead of the previous neon cyan (#00fff7).

- Theme primary and secondary colors
- Sidebar icons, borders, shadows, and text
- Header text, borders, and shadows
- MainContent heading and shadows
- Any other component or style using the old neon cyan or similar

Closes #10.